### PR TITLE
cria endpoint de consulta da policy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development, :test do
   gem "standard-rails"
   gem "pry-byebug"
   gem "rspec-rails", "~> 4.1.2"
+  gem "ruby-lsp"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -112,17 +113,13 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
+    prism (0.30.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    pry-rails (0.3.11)
-      pry (>= 0.13.0)
-    pry-remote (0.1.8)
-      pry (~> 0.9)
-      slop (~> 3.0)
     puma (5.6.8)
       nio4r (~> 2.0)
     racc (1.8.0)
@@ -162,6 +159,8 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rbs (3.5.1)
+      logger
     regexp_parser (2.9.2)
     rexml (3.3.0)
       strscan
@@ -203,8 +202,13 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
+    ruby-lsp (0.17.4)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 0.29.0, < 0.31)
+      rbs (>= 3, < 4)
+      sorbet-runtime (>= 0.5.10782)
     ruby-progressbar (1.13.0)
-    slop (3.6.0)
+    sorbet-runtime (0.5.11447)
     spring (4.2.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
@@ -247,11 +251,10 @@ DEPENDENCIES
   listen (~> 3.3)
   pg (~> 1.1)
   pry-byebug
-  pry-rails
-  pry-remote
   puma (~> 5.0)
   rails (~> 6.1.7, >= 6.1.7.8)
   rspec-rails (~> 4.1.2)
+  ruby-lsp
   spring
   standard
   standard-rails

--- a/app/controllers/api/v1/policy_controller.rb
+++ b/app/controllers/api/v1/policy_controller.rb
@@ -1,0 +1,33 @@
+class Api::V1::PolicyController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  def show
+    binding.pry
+    @policy = Policy.find(params[:id])
+    render json: {payload: policy}, status: :ok if @policy.present?
+  end
+
+  private
+
+  def record_not_found
+    render plain: "404 Not Found", status: :not_found
+  end
+
+  def policy
+    {
+      policy_id: @policy.id,
+      start_date_coverage: @policy.start_date_coverage,
+      end_date_coverage: @policy.end_date_coverage,
+      insured: {
+        name: @policy.insured.name,
+        cpf: @policy.insured.cpf
+      },
+      vehicle: {
+        brand: @policy.vehicle.brand,
+        model: @policy.vehicle.model,
+        year: @policy.vehicle.year,
+        registration_plate: @policy.vehicle.registration_plate
+      }
+    }
+  end
+end

--- a/app/models/insured.rb
+++ b/app/models/insured.rb
@@ -1,0 +1,3 @@
+class Insured < ApplicationRecord
+  has_many :policies, dependent: :destroy
+end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -1,0 +1,4 @@
+class Policy < ApplicationRecord
+  belongs_to :insured
+  belongs_to :vehicle
+end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,0 +1,3 @@
+class Vehicle < ApplicationRecord
+  has_many :policies, dependent: :destroy
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      get "/policy/:id", to: "policy#show"
+    end
+  end
 end

--- a/db/migrate/20240626152152_create_vehicles.rb
+++ b/db/migrate/20240626152152_create_vehicles.rb
@@ -1,0 +1,12 @@
+class CreateVehicles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :vehicles do |t|
+      t.string :registration_plate
+      t.string :brand
+      t.string :model
+      t.string :year
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240626152555_create_insureds.rb
+++ b/db/migrate/20240626152555_create_insureds.rb
@@ -1,0 +1,10 @@
+class CreateInsureds < ActiveRecord::Migration[6.1]
+  def change
+    create_table :insureds do |t|
+      t.string :name
+      t.string :cpf
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240626152740_create_policies.rb
+++ b/db/migrate/20240626152740_create_policies.rb
@@ -1,0 +1,12 @@
+class CreatePolicies < ActiveRecord::Migration[6.1]
+  def change
+    create_table :policies do |t|
+      t.date :start_date_coverage
+      t.date :end_date_coverage
+      t.references :insured, null: false, foreign_key: true
+      t.references :vehicle, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,46 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2024_06_26_152740) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "insureds", force: :cascade do |t|
+    t.string "name"
+    t.string "cpf"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "policies", force: :cascade do |t|
+    t.date "start_date_coverage"
+    t.date "end_date_coverage"
+    t.bigint "insured_id", null: false
+    t.bigint "vehicle_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["insured_id"], name: "index_policies_on_insured_id"
+    t.index ["vehicle_id"], name: "index_policies_on_vehicle_id"
+  end
+
+  create_table "vehicles", force: :cascade do |t|
+    t.string "registration_plate"
+    t.string "brand"
+    t.string "model"
+    t.string "year"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  add_foreign_key "policies", "insureds"
+  add_foreign_key "policies", "vehicles"
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,3 +6,32 @@
 #   movies = Movie.create![{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create!name: 'Luke', movie: movies.first)
 
+mad_max = Insured.create!(name: "Mad Max", cpf: "96151218000")
+interceptor = Vehicle.create!(brand: "Ford", model: "Falcon GT", year: 1973,
+  registration_plate: "Interceptor-v6")
+Policy.create!(start_date_coverage: Date.new(1974, 5, 30),
+  end_date_coverage: Date.new(2030, 5, 30), insured_id: mad_max.id, vehicle_id: interceptor.id)
+
+marty = Insured.create!(name: "Marty McFly", cpf: "12345678901")
+delorean = Vehicle.create!(brand: "DeLorean", model: "DMC-12", year: 1981,
+  registration_plate: "OUTATIME")
+Policy.create!(start_date_coverage: Date.new(1981, 2, 12),
+  end_date_coverage: Date.new(2030, 2, 12), insured_id: marty.id, vehicle_id: delorean.id)
+
+bo_duke = Insured.create!(name: "Bo Duke", cpf: "23456789012")
+general_lee = Vehicle.create!(brand: "Dodge", model: "Charger", year: 1969,
+  registration_plate: "General Lee")
+Policy.create!(start_date_coverage: Date.new(1969, 1, 10),
+  end_date_coverage: Date.new(2030, 1, 10), insured_id: bo_duke.id, vehicle_id: general_lee.id)
+
+fred = Insured.create!(name: "Fred Jones", cpf: "34567890123")
+mystery_machine = Vehicle.create!(brand: "Ford", model: "Econoline", year: 1978,
+  registration_plate: "Mystery Machine")
+Policy.create!(start_date_coverage: Date.new(1978, 5, 15),
+  end_date_coverage: Date.new(2030, 5, 15), insured_id: fred.id, vehicle_id: mystery_machine.id)
+
+sam = Insured.create!(name: "Sam Witwicky", cpf: "45678901234")
+bumblebee = Vehicle.create!(brand: "Chevrolet", model: "Camaro", year: 1977,
+  registration_plate: "BEE")
+Policy.create!(start_date_coverage: Date.new(1977, 6, 18),
+  end_date_coverage: Date.new(2030, 6, 18), insured_id: sam.id, vehicle_id: bumblebee.id)

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Policy, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/segurado_spec.rb
+++ b/spec/models/segurado_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Segurado, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Vehicle, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  def parsed_response
+    JSON.parse(response.body, symbolize_names: true)
+  end
 end

--- a/spec/requests/policies_spec.rb
+++ b/spec/requests/policies_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "Policy", type: :request do
+  mad_max = Insured.create!(name: "Mad Max", cpf: "96151218000")
+  interceptor = Vehicle.create!(brand: "Ford", model: "Falcon GT", year: 1973,
+    registration_plate: "Interceptor-v6")
+  policy = Policy.create!(start_date_coverage: Date.new(1974, 5, 30),
+    end_date_coverage: Date.new(2030, 5, 30), insured_id: mad_max.id, vehicle_id: interceptor.id)
+  let(:wrong_id) { 10 }
+
+  describe "GET /policy/:id" do
+    context "when valid" do
+      it "return status 200" do
+        get "/api/v1/policy/#{policy.id}"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "return a policy" do
+        get "/api/v1/policy/#{policy.id}"
+        expect(parsed_response[:payload][:policy_id]).to eq(policy.id)
+        expect(parsed_response[:payload][:start_date_coverage]).to eq("1974-05-30")
+        expect(parsed_response[:payload][:end_date_coverage]).to eq("2030-05-30")
+        expect(parsed_response[:payload][:insured][:name]).to eq(mad_max.name)
+        expect(parsed_response[:payload][:insured][:cpf]).to eq(mad_max.cpf)
+        expect(parsed_response[:payload][:vehicle][:brand]).to eq(interceptor.brand)
+        expect(parsed_response[:payload][:vehicle][:model]).to eq(interceptor.model)
+        expect(parsed_response[:payload][:vehicle][:year]).to eq(interceptor.year)
+        expect(parsed_response[:payload][:vehicle][:registration_plate]).to eq(interceptor.registration_plate)
+      end
+    end
+
+    context "when invalid" do
+      it "return status 404" do
+        get "/api/v1/policy/#{wrong_id}"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "return an error" do
+        get "/api/v1/policy/#{wrong_id}"
+        expect(response.body).to eq("404 Not Found")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## O que mudou
Adiciona endpoints de consulta de uma apólice.

## Motivação
Precisamos de endpoint `GET /policies/:policy_id` que consumirá mensagens de policy_created da fila do rabbitMQ

## Como testar
* Subir o projeto usando o comando `docker-compose up`

Fazer o request pelo curl
```
curl --request GET \
  --url http://0.0.0.0:3001/api/v1/policy/5 \
  --header 'Content-Type: application/json' \
  --data '{
	"start_date": "05-10-1994",
	"end_date": "05-10-1999",
	"insured_id": "1"
}'
```
Ou pelo insomnia

### Resposta esperada
![Captura de tela de 2024-06-26 13-29-38](https://github.com/ventopreto/rest_app/assets/67896322/1355303a-e71b-4cf6-8b59-3a106ab3402e)

## Solução proposta
adicionar uma rola para o endpoint, criar os modelos e popular o banco com alguns dados para teste

## Riscos
Risco do endpoint não funcionar corretamente por falta de algum dado

## Impactos negativos previstos
Nenhum Impacto previsto

## Instruções para deploy
Nenhuma instrução adicional

## Instruções para retorno
rollback padrão desse PR
