### PR TITLE
Cria adiciona rabbitmq e cria service consumer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,10 @@ group :development do
 end
 
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# Rabbit
+gem "bunny", ">= 2.19.0"
+
+group :test do
+  gem "bunny-mock"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,10 +60,16 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    amq-protocol (2.3.2)
     ast (2.4.2)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    bunny (2.23.0)
+      amq-protocol (~> 2.3, >= 2.3.1)
+      sorted_set (~> 1, >= 1.0.2)
+    bunny-mock (1.7.0)
+      bunny (>= 1.7)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.3.3)
@@ -161,6 +167,7 @@ GEM
       ffi (~> 1.0)
     rbs (3.5.1)
       logger
+    rbtree (0.4.6)
     regexp_parser (2.9.2)
     rexml (3.3.0)
       strscan
@@ -208,7 +215,11 @@ GEM
       rbs (>= 3, < 4)
       sorbet-runtime (>= 0.5.10782)
     ruby-progressbar (1.13.0)
+    set (1.1.0)
     sorbet-runtime (0.5.11447)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     spring (4.2.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
@@ -248,6 +259,8 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
+  bunny (>= 2.19.0)
+  bunny-mock
   listen (~> 3.3)
   pg (~> 1.1)
   pry-byebug

--- a/app/services/consumer.rb
+++ b/app/services/consumer.rb
@@ -1,0 +1,59 @@
+require "bunny"
+
+class Consumer
+  class << self
+    def connection
+      @connection ||= Bunny.new(host: "rabbitmq", user: "user", pass: "password").start
+    end
+
+    def channel
+      @channel ||= connection.create_channel
+    end
+
+    def exchange
+      @exchange ||= channel.fanout("policy_created")
+    end
+
+    def queue
+      @queue ||= channel.queue("", exclusive: true)
+    end
+
+    def subscribe
+      queue.bind(exchange)
+
+      puts " [*] Waiting for logs. To exit press CTRL+C"
+
+      begin
+        queue.subscribe(block: true) do |_delivery_info, _properties, body|
+          puts " [x] Received: #{body}"
+          parsed_body = JSON.parse(body)
+
+          vehicle = Vehicle.create!(
+            brand: parsed_body["vehicle"]["brand"],
+            model: parsed_body["vehicle"]["model"],
+            year: parsed_body["vehicle"]["year"],
+            registration_plate: parsed_body["vehicle"]["registration_plate"]
+          )
+
+          insured = Insured.create!(
+            name: parsed_body["insured"]["name"],
+            cpf: parsed_body["insured"]["cpf"]
+          )
+
+          Policy.create!(
+            start_date_coverage: Date.parse(parsed_body["start_date_coverage"]),
+            end_date_coverage: Date.parse(parsed_body["end_date_coverage"]),
+            insured_id: insured.id,
+            vehicle_id: vehicle.id
+          )
+        end
+      rescue Interrupt => _
+        channel.close
+        connection.close
+        puts "Connection closed"
+      rescue => e
+        puts "Subscription error: #{e.message}"
+      end
+    end
+  end
+end

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,19 @@
+services:
+  web:
+    networks:
+      - public
+      - private
+    container_name: rest_app
+  db:
+    networks:
+      - private
+  rabbitmq:
+    networks:
+      - public
+
+networks:
+  public:
+    external: true
+  private:
+    external: false
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,17 @@ services:
       - ./tmp/db:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: password
+  rabbitmq:
+    image: rabbitmq:3-management
+    hostname: rabbitmq
+    expose:
+      - "5672"
+    ports:
+    - "5672:5672"
+    - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: user
+      RABBITMQ_DEFAULT_PASS: password
   web:
     tty: true
     stdin_open: true
@@ -12,7 +23,12 @@ services:
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3001 -b '0.0.0.0'"
     volumes:
       - .:/myapp
+      - gems_cache:/usr/local/bundle
     ports:
       - "3001:3001"
     depends_on:
       - db
+      - rabbitmq
+
+volumes:
+  gems_cache:

--- a/spec/services/consumer_spec.rb
+++ b/spec/services/consumer_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+require "bunny-mock"
+
+RSpec.describe Consumer do
+  let(:connection) { BunnyMock.new }
+  let(:channel) { connection.create_channel }
+  let(:queue) { channel.queue("", exclusive: true) }
+  let(:message) do
+    {
+      start_date_coverage: "1994-10-05",
+      end_date_coverage: "1998-11-10",
+      vehicle: {
+        brand: "DeLorean",
+        model: "DMC-12",
+        year: "1981",
+        registration_plate: "OUTATIME"
+      },
+      insured: {
+        name: "Marty McFly",
+        cpf: "12345678901"
+      }
+    }
+  end
+
+  before do
+    allow(Bunny).to receive(:new).and_return(connection)
+  end
+
+  describe ".subscribe" do
+    it "consume messages from the policy_created exchange and persist data" do
+      allow(queue).to receive(:subscribe).and_yield(nil, nil, message.to_json)
+
+      expect { described_class.subscribe }.to change(Vehicle, :count).by(1)
+        .and change(Policy, :count).by(1)
+        .and change(Insured, :count).by(1)
+      expect(Vehicle.last.registration_plate).to eq("OUTATIME")
+      expect(Vehicle.last.brand).to eq("DeLorean")
+      expect(Vehicle.last.model).to eq("DMC-12")
+      expect(Vehicle.last.year).to eq("1981")
+    end
+  end
+
+  describe ".exchange" do
+    it "creates a new exchange" do
+      expect(described_class.exchange).to be_a(BunnyMock::Exchange)
+    end
+  end
+
+  describe ".channel" do
+    it "creates a new channel" do
+      expect(described_class.channel).to be_a(BunnyMock::Channel)
+    end
+  end
+
+  describe ".connection" do
+    it "creates a new connection" do
+      expect(described_class.connection).to be_a(BunnyMock::Session)
+    end
+  end
+end


### PR DESCRIPTION
## O que mudou
adiciona rabbitmq ao projeto

## Motivação
Precisamos adicionar o rabbitmq ao projeto, precisamos consumir as mensagens de criação vindas do graphql

## Solução proposta
O rabbitmq foi adicionado como um serviço ao docker-compose, adicionamos um service chamado "Consumer" responsável por consumir as mensagens na fila vindas do graphql

## Como testar
### APP Rest
* Suba o` app rest` utilizando o comando `docker-compose -f docker-compose.yml -f docker-compose.local.yml up`
* Inicie o `consumer`, vá até o console e Digite `Consumer.subscribe`
* Acessar o [endereço](http://localhost:15672/#/exchanges)
* Username: "user"
* Password: "password"

Se tudo correr bem, uma fila não nomeada será criada como na imagem abaixo

![Captura de tela de 2024-07-02 15-11-40](https://github.com/ventopreto/rest_app/assets/67896322/c56ea8bf-df21-4f33-8b30-9ea4e303df7a)

### APP GRAPHQL
* Suba o [app graphql](https://github.com/ventopreto/graphql_app) utilizando o comando `docker-compose -f docker-compose.yml -f docker-compose.local.yml up`

### GraphiQL:

<details>
<summary><strong>Crie uma nova apólice</strong>  </summary><br>

* Acesse http://0.0.0.0:3000/graphiql
* cole o código abaixo e aperte ctrl+enter

#### Exemplo de Mutation
```GQL
mutation{
  policyCreate(input: {policyInput: {
    start_date_coverage: "1994-10-05"
    end_date_coverage: "1994-11-10"
    vehicle: {
      brand: "Ford"
      model: "Falcon GT"
      year: "1973"
      registration_plate: "Interceptor-v6"
    	}
    insured: {
      name: "Mad Max"
      cpf: "96151218000"
    }
  	}
  }
  ) {
    message
  }
}

```

Volte ao APP Rest e verifique se os dados foram persistidos corretamente.

![criação da apólice](https://github.com/ventopreto/rest_app/assets/67896322/2c9c8245-4044-4051-925e-526cbd454da3)

</details>

## Riscos
Podemos ter problemas de comunicação entre os dois apps durante os testes.

## Impactos negativos previstos
Nenhum Impacto previsto

## Instruções para deploy
Nenhuma instrução adicional

## Instruções para retorno
rollback padrão desse PR

