### PR TITLE
configura actioncable com adapter redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "devise"
 gem "devise-jwt"
 gem "dotenv"
 gem "active_model_serializers"
+gem "redis", "~> 4.0"
 
 group :development, :test do
   gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,7 @@ GEM
     rbs (3.5.1)
       logger
     rbtree (0.4.6)
+    redis (4.8.1)
     regexp_parser (2.9.2)
     responders (3.1.1)
       actionpack (>= 5.2)
@@ -326,6 +327,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 5.0)
   rails (~> 6.1.7, >= 6.1.7.8)
+  redis (~> 4.0)
   rspec-rails (~> 4.1.2)
   ruby-lsp
   sneakers

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+  end
+end

--- a/app/channels/list_of_policies_channel.rb
+++ b/app/channels/list_of_policies_channel.rb
@@ -1,0 +1,9 @@
+class ListOfPoliciesChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "ListOfPoliciesChannel"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/workers/policy_paid.rb
+++ b/app/workers/policy_paid.rb
@@ -4,12 +4,24 @@ class PolicyPaid
   from_queue "policy_paid", ack: true
 
   def work(message)
-    puts "[x] Received: #{message}"
     response = JSON.parse(message)
     order_id = response["metadata"]["order_id"]
-    return if order_id.blank? || response["payment_status"] != "paid"
+    return ack! if order_id.blank? || response["payment_status"] != "paid"
+
     policy = Policy.find_by(payment_id: order_id)
-    policy.update(payment_status: 1)
+    if policy
+      policy.update(payment_status: 1)
+      ActionCable.server.broadcast "ListOfPoliciesChannel", policy
+    else
+      Sneakers.logger.error "Policy with payment_id #{order_id} not found"
+    end
+
     ack!
+  rescue JSON::ParserError => e
+    Sneakers.logger.error "Failed to parse message: #{e.message}"
+    reject!
+  rescue => e
+    Sneakers.logger.error "Unexpected error: #{e.message}"
+    reject!
   end
 end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,6 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://redis:6379/1
 
 test:
   adapter: test

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount ActionCable.server => '/cable'
   namespace :api do
     namespace :v1 do
       get "/policy/:id", to: "policy#show"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -10,6 +10,9 @@ services:
   rabbitmq:
     networks:
       - public
+  redis:
+    networks:
+      - public
 
 networks:
   public:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,11 @@ services:
     depends_on:
       - db
       - rabbitmq
+      - redis
+  redis:
+    image: redis:latest
+    ports:
+      - "6380:6379"
 
 volumes:
   gems_cache:


### PR DESCRIPTION
## O que mudou
Após receber uma mensagem na fila policy_paid, o worker marca a apólice como paga sem precisar de refresh

## Motivação
Vamos transformar a página de listagem de apólices para utilizar uma conexão web socket com a API GraphQL, desta forma a pessoa não precisa ficar fazendo "refresh" na página. Quando o Stripe responder, o worker que fica consumindo o evento do Stripe faz chamada a um endpoint que coloca a informação atualizada no canal WebSocket.

## Solução proposta
Configurar o action cable para poder transmitir mensagens num canal que será recebido pelo front_app

## Como testar
### [APP GRAPHQL](https://github.com/ventopreto/graphql_app/tree/feature/configura_webhook_stripe)
* Suba o [app graphql](https://github.com/ventopreto/graphql_app/tree/feature/configura_webhook_stripe) utilizando o comando `docker-compose -f docker-compose.yml -f docker-compose.local.yml up`

### [APP Rest](https://github.com/ventopreto/rest_app/tree/feature/worker_de_apolice_paga)
* Suba o [app rest](https://github.com/ventopreto/rest_app/tree/feature/worker_de_apolice_paga) utilizando o comando `docker-compose -f docker-compose.yml -f docker-compose.local.yml up`
* Inicie o `consumer`, entre no container e Digite `rake sneakers:run`
* Acessar o [endereço](http://localhost:15672/#/exchanges)
* Username: "user"
* Password: "password"

Se tudo correr bem, duas filas seram criadas "policy_paid" e "policy_created"

### [APP Front](https://github.com/ventopreto/front_app/tree/feat/adiciona_stripe)
* Suba o [app front ](https://github.com/ventopreto/front_app/tree/feat/adiciona_stripe)utilizando o comando `docker-compose -f docker-compose.yml -f docker-compose.local.yml up`
* Faça Login ou crie uma nova conta 
* Clique na aba Criar Apolice
* Preencha os campos e clique em cadastrar

Você será redirecionado para a listagem de apólices.

![Captura de tela de 2024-08-02 16-32-14](https://github.com/user-attachments/assets/2d9c0e21-9e1e-4aaf-9623-7a92a5dfa52d)

Clicando no botão de pagar você será redirecionado para o checkout do Stripe, preenchendo os dados o pagamento será feito corretamente.

Para o webhook funcionar corretamente, precisamos realizar uma série de configurações como usar o ngrok e configurar na dashboard do stripe o webhook com o host publico do ngrok.

Abaixo um gif onde realizo toda a operação.

![testando_websocket_pagamento funcionando](https://github.com/user-attachments/assets/616a0bde-59f3-4bbb-ab8d-c413abd95ecc)

## Riscos
Podemos ter problemas de comunicação entre os três apps durante os testes.

## Impactos negativos previstos
Nenhum Impacto previsto

## Instruções para deploy
Nenhuma instrução adicional

## Instruções para retorno
rollback padrão desse PR

